### PR TITLE
로그인 API 구현

### DIFF
--- a/green/src/main/java/com/greengrim/green/common/exception/errorCode/MemberErrorCode.java
+++ b/green/src/main/java/com/greengrim/green/common/exception/errorCode/MemberErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
     EMPTY_MEMBER("MEMBER_001", "존재하지 않는 사용자입니다.", HttpStatus.CONFLICT),
     DUPLICATE_MEMBER("MEMBER_002", "중복된 사용자입니다.", HttpStatus.CONFLICT),
-    DUPLICATE_NICKNAME("MEMBER_003", "중복된 닉네임입니다.", HttpStatus.CONFLICT)
+    DUPLICATE_NICKNAME("MEMBER_003", "중복된 닉네임입니다.", HttpStatus.CONFLICT),
+    UN_REGISTERED_MEMBER("MEMBER_004", "등록되지 않은 이메일입니다.", HttpStatus.CONFLICT)
     ;
 
     private final String errorCode;

--- a/green/src/main/java/com/greengrim/green/core/member/controller/RegisterMemberController.java
+++ b/green/src/main/java/com/greengrim/green/core/member/controller/RegisterMemberController.java
@@ -29,4 +29,16 @@ public class RegisterMemberController {
         return new ResponseEntity<>(registerMemberUseCase.registerMember(registerMember),
                 HttpStatus.OK);
     }
+
+    /**
+     * [POST] 로그인
+     * /login
+     */
+    @Operation(summary = "로그인")
+    @PostMapping("/login")
+    public ResponseEntity<MemberResponseDto.TokenInfo> login(
+            @Valid @RequestBody MemberRequestDto.LoginMember loginMember) {
+        return new ResponseEntity<>(registerMemberUseCase.login(loginMember),
+                HttpStatus.OK);
+    }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/dto/MemberRequestDto.java
+++ b/green/src/main/java/com/greengrim/green/core/member/dto/MemberRequestDto.java
@@ -20,4 +20,12 @@ public class MemberRequestDto {
         private String introduction;
         private String profileImgUrl;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LoginMember {
+        @Email(message= "이메일 형식이 아닙니다.")
+        private String email;
+    }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/repository/MemberRepository.java
+++ b/green/src/main/java/com/greengrim/green/core/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsByNickName(String nickName);
 
     Optional<Member> findByIdAndStatusTrue(@Param("memberId") Long memberId);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/green/src/main/java/com/greengrim/green/core/member/service/RegisterMemberService.java
+++ b/green/src/main/java/com/greengrim/green/core/member/service/RegisterMemberService.java
@@ -59,4 +59,16 @@ public class RegisterMemberService implements RegisterMemberUseCase {
             throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
         }
     }
+
+    @Override
+    public MemberResponseDto.TokenInfo login(MemberRequestDto.LoginMember loginMember) {
+        Member member = memberRepository.findByEmail(loginMember.getEmail()).orElse(null);
+        if (member != null) {
+            MemberResponseDto.TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getId());
+            member.changeRefreshToken(tokenInfo.getRefreshToken());
+            return tokenInfo;
+        } else {
+            throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
+        }
+    }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/usecase/RegisterMemberUseCase.java
+++ b/green/src/main/java/com/greengrim/green/core/member/usecase/RegisterMemberUseCase.java
@@ -6,4 +6,5 @@ import com.greengrim.green.core.member.dto.MemberResponseDto;
 public interface RegisterMemberUseCase {
 
     MemberResponseDto.TokenInfo registerMember(MemberRequestDto.RegisterMember registerMember);
+    MemberResponseDto.TokenInfo login(MemberRequestDto.LoginMember loginMember);
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

#29

### 📝 구현 내용

- 이메일을 받아 유효성을 검사합니다!
- 만약, 존재하는 이메일일 경우 로그인 처리 OK. 다시 토큰을 발급해줍니다.
- 하지만 존재하지 않는 이메일이라면 등록되지 않은 이메일이라는 에러가 내려갑니다! 그러면 프론트 측에서 회원가입 화면으로 유도하는게 로직입니다.
