### PR TITLE
닉네임 중복 확인 API & 토큰 재발급 API 구현

### DIFF
--- a/green/src/main/java/com/greengrim/green/common/config/SecurityConfig.java
+++ b/green/src/main/java/com/greengrim/green/common/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -26,14 +27,11 @@ public class SecurityConfig {
         http
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class)
-                .csrf((csrfConfig) ->
-                        csrfConfig.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .formLogin((formLogin) ->
-                        formLogin.disable())
-                .httpBasic((httpBasic) ->
-                        httpBasic.disable())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
                         .requestMatchers("/visitor/**").hasAnyRole("VISITOR", "MEMBER", "MANAGER")

--- a/green/src/main/java/com/greengrim/green/common/jwt/JwtAuthenticationFilter.java
+++ b/green/src/main/java/com/greengrim/green/common/jwt/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         String token = jwtTokenProvider.resolveAccessToken((HttpServletRequest) request);
         // 헤더에 refreshToken을 보냈다면 refreshToken 유효성 검사 및 authentication 세팅
         if (refreshToken != null && ((HttpServletRequest) request).getRequestURI()
-                .equals("/member/refresh") && jwtTokenProvider.validateRefreshToken(refreshToken)) {
+                .equals("/visitor/refresh") && jwtTokenProvider.validateRefreshToken(refreshToken)) {
             Authentication authentication = jwtTokenProvider.getRefreshAuthentication(refreshToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/green/src/main/java/com/greengrim/green/core/member/controller/RegisterMemberController.java
+++ b/green/src/main/java/com/greengrim/green/core/member/controller/RegisterMemberController.java
@@ -25,8 +25,8 @@ public class RegisterMemberController {
     @Operation(summary = "소셜 회원가입")
     @PostMapping("/sign-up")
     public ResponseEntity<MemberResponseDto.TokenInfo> register(
-            @Valid @RequestBody MemberRequestDto.RegisterMember registerMember) {
-        return new ResponseEntity<>(registerMemberUseCase.registerMember(registerMember),
+            @Valid @RequestBody MemberRequestDto.RegisterMemberReq registerMemberReq) {
+        return new ResponseEntity<>(registerMemberUseCase.registerMember(registerMemberReq),
                 HttpStatus.OK);
     }
 
@@ -37,8 +37,19 @@ public class RegisterMemberController {
     @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<MemberResponseDto.TokenInfo> login(
-            @Valid @RequestBody MemberRequestDto.LoginMember loginMember) {
-        return new ResponseEntity<>(registerMemberUseCase.login(loginMember),
+            @Valid @RequestBody MemberRequestDto.LoginMemberReq loginMemberReq) {
+        return new ResponseEntity<>(registerMemberUseCase.login(loginMemberReq),
+                HttpStatus.OK);
+    }
+
+    /**
+     * [POST] 닉네임 중복 확인
+     * /nick-name
+     */
+    @PostMapping("/nick-name")
+    public ResponseEntity<MemberResponseDto.CheckNickNameRes> checkNickName(
+            @Valid @RequestBody MemberRequestDto.CheckNickNameReq checkNickNameReq) {
+        return new ResponseEntity<>(registerMemberUseCase.checkNickName(checkNickNameReq),
                 HttpStatus.OK);
     }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/controller/UpdateMemberController.java
+++ b/green/src/main/java/com/greengrim/green/core/member/controller/UpdateMemberController.java
@@ -1,0 +1,28 @@
+package com.greengrim.green.core.member.controller;
+
+import com.greengrim.green.common.auth.CurrentMember;
+import com.greengrim.green.core.member.Member;
+import com.greengrim.green.core.member.dto.MemberResponseDto;
+import com.greengrim.green.core.member.usecase.UpdateMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateMemberController {
+
+    private final UpdateMemberUseCase updateMemberUseCase;
+
+    /**
+     * [PATCH] 로그인 토큰 갱신
+     */
+    @PatchMapping("/visitor/refresh")
+    public ResponseEntity<MemberResponseDto.TokenInfo> refreshLogin(
+            @CurrentMember Member member) {
+        return new ResponseEntity<>(updateMemberUseCase.refreshAccessToken(member),
+                HttpStatus.OK);
+    }
+}

--- a/green/src/main/java/com/greengrim/green/core/member/dto/MemberRequestDto.java
+++ b/green/src/main/java/com/greengrim/green/core/member/dto/MemberRequestDto.java
@@ -11,7 +11,7 @@ public class MemberRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RegisterMember {
+    public static class RegisterMemberReq {
 
         @Email(message = "이메일 형식이 아닙니다.")
         private String email;
@@ -24,8 +24,16 @@ public class MemberRequestDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class LoginMember {
+    public static class LoginMemberReq {
         @Email(message= "이메일 형식이 아닙니다.")
         private String email;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CheckNickNameReq {
+        @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+        private String nickName;
     }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/dto/MemberResponseDto.java
+++ b/green/src/main/java/com/greengrim/green/core/member/dto/MemberResponseDto.java
@@ -11,4 +11,11 @@ public class MemberResponseDto {
         private String accessToken;
         private String refreshToken;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CheckNickNameRes {
+
+        private boolean isUsed;
+    }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/service/RegisterMemberService.java
+++ b/green/src/main/java/com/greengrim/green/core/member/service/RegisterMemberService.java
@@ -23,12 +23,12 @@ public class RegisterMemberService implements RegisterMemberUseCase {
         memberRepository.save(member);
     }
 
-    public Member register(MemberRequestDto.RegisterMember registerMember) {
+    public Member register(MemberRequestDto.RegisterMemberReq registerMemberReq) {
         Member member = Member.builder()
-                .email(registerMember.getEmail())
-                .nickName(registerMember.getNickName())
-                .introduction(registerMember.getIntroduction())
-                .profileImgUrl(registerMember.getProfileImgUrl())
+                .email(registerMemberReq.getEmail())
+                .nickName(registerMemberReq.getNickName())
+                .introduction(registerMemberReq.getIntroduction())
+                .profileImgUrl(registerMemberReq.getProfileImgUrl())
                 .point(0)
                 .reportCnt(0)
                 .status(true)
@@ -41,28 +41,28 @@ public class RegisterMemberService implements RegisterMemberUseCase {
     }
 
     @Override
-    public MemberResponseDto.TokenInfo registerMember(MemberRequestDto.RegisterMember registerMember) {
-        checkRegister(registerMember);
-        Member member = register(registerMember);
+    public MemberResponseDto.TokenInfo registerMember(MemberRequestDto.RegisterMemberReq registerMemberReq) {
+        checkRegister(registerMemberReq);
+        Member member = register(registerMemberReq);
         MemberResponseDto.TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getId());
         member.changeRefreshToken(tokenInfo.getRefreshToken());
         return tokenInfo;
     }
 
-    public void checkRegister(MemberRequestDto.RegisterMember registerMember) {
-        Boolean flag = memberRepository.existsByEmail(registerMember.getEmail());
+    public void checkRegister(MemberRequestDto.RegisterMemberReq registerMemberReq) {
+        Boolean flag = memberRepository.existsByEmail(registerMemberReq.getEmail());
         if (flag) {
             throw new BaseException(MemberErrorCode.DUPLICATE_MEMBER);
         }
-        flag = memberRepository.existsByNickName(registerMember.getNickName());
+        flag = memberRepository.existsByNickName(registerMemberReq.getNickName());
         if (flag) {
             throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
         }
     }
 
     @Override
-    public MemberResponseDto.TokenInfo login(MemberRequestDto.LoginMember loginMember) {
-        Member member = memberRepository.findByEmail(loginMember.getEmail()).orElse(null);
+    public MemberResponseDto.TokenInfo login(MemberRequestDto.LoginMemberReq loginMemberReq) {
+        Member member = memberRepository.findByEmail(loginMemberReq.getEmail()).orElse(null);
         if (member != null) {
             MemberResponseDto.TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getId());
             member.changeRefreshToken(tokenInfo.getRefreshToken());
@@ -70,5 +70,11 @@ public class RegisterMemberService implements RegisterMemberUseCase {
         } else {
             throw new BaseException(MemberErrorCode.UN_REGISTERED_MEMBER);
         }
+    }
+
+    @Override
+    public MemberResponseDto.CheckNickNameRes checkNickName(MemberRequestDto.CheckNickNameReq checkNickNameReq) {
+        return new MemberResponseDto.CheckNickNameRes(
+                memberRepository.existsByNickName(checkNickNameReq.getNickName()));
     }
 }

--- a/green/src/main/java/com/greengrim/green/core/member/service/UpdateMemberService.java
+++ b/green/src/main/java/com/greengrim/green/core/member/service/UpdateMemberService.java
@@ -1,0 +1,23 @@
+package com.greengrim.green.core.member.service;
+
+import com.greengrim.green.common.jwt.JwtTokenProvider;
+import com.greengrim.green.core.member.Member;
+import com.greengrim.green.core.member.dto.MemberResponseDto;
+import com.greengrim.green.core.member.usecase.UpdateMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMemberService implements UpdateMemberUseCase {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public MemberResponseDto.TokenInfo refreshAccessToken(Member member) {
+        MemberResponseDto.TokenInfo newTokenInfo
+                = jwtTokenProvider.generateToken(member.getId());
+        return new MemberResponseDto.TokenInfo(
+                newTokenInfo.getAccessToken(), member.getRefreshToken());
+    }
+}

--- a/green/src/main/java/com/greengrim/green/core/member/usecase/RegisterMemberUseCase.java
+++ b/green/src/main/java/com/greengrim/green/core/member/usecase/RegisterMemberUseCase.java
@@ -5,6 +5,7 @@ import com.greengrim.green.core.member.dto.MemberResponseDto;
 
 public interface RegisterMemberUseCase {
 
-    MemberResponseDto.TokenInfo registerMember(MemberRequestDto.RegisterMember registerMember);
-    MemberResponseDto.TokenInfo login(MemberRequestDto.LoginMember loginMember);
+    MemberResponseDto.TokenInfo registerMember(MemberRequestDto.RegisterMemberReq registerMemberReq);
+    MemberResponseDto.TokenInfo login(MemberRequestDto.LoginMemberReq loginMemberReq);
+    MemberResponseDto.CheckNickNameRes checkNickName(MemberRequestDto.CheckNickNameReq checkNickNameReq);
 }

--- a/green/src/main/java/com/greengrim/green/core/member/usecase/UpdateMemberUseCase.java
+++ b/green/src/main/java/com/greengrim/green/core/member/usecase/UpdateMemberUseCase.java
@@ -1,0 +1,9 @@
+package com.greengrim.green.core.member.usecase;
+
+import com.greengrim.green.core.member.Member;
+import com.greengrim.green.core.member.dto.MemberResponseDto;
+
+public interface UpdateMemberUseCase {
+
+    MemberResponseDto.TokenInfo refreshAccessToken(Member member);
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

#29

### 📝 구현 내용

- 닉네임 중복 확인
- accessToken이 만료 됐을 때 refreshToken을 헤더에 담아 보내면 accessToken 재발급
- 테스트 완료

