### PR TITLE
채팅 기능 - 프로젝트 적용 테스트

### DIFF
--- a/green/src/main/java/com/greengrim/green/common/config/EmbeddedRedisConfig.java
+++ b/green/src/main/java/com/greengrim/green/common/config/EmbeddedRedisConfig.java
@@ -18,7 +18,10 @@ public class EmbeddedRedisConfig {
 
   @PostConstruct
   public void redisServer() {
-    redisServer = new RedisServer(redisPort);
+    redisServer = RedisServer.builder()
+        .port(redisPort)
+        .setting("maxmemory 128M")
+        .build();
     redisServer.start();
   }
 

--- a/green/src/main/java/com/greengrim/green/common/redis/RedisSubscriber.java
+++ b/green/src/main/java/com/greengrim/green/common/redis/RedisSubscriber.java
@@ -1,7 +1,7 @@
 package com.greengrim.green.common.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.greengrim.green.core.chat.dto.ChatMessage;
+import com.greengrim.green.core.chat.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;

--- a/green/src/main/java/com/greengrim/green/core/chat/ChatController.java
+++ b/green/src/main/java/com/greengrim/green/core/chat/ChatController.java
@@ -1,27 +1,34 @@
 package com.greengrim.green.core.chat;
 
 import com.greengrim.green.common.jwt.JwtTokenProvider;
-import com.greengrim.green.core.chat.dto.ChatMessage;
-import com.greengrim.green.core.chatRoom.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
 @Controller
 public class ChatController {
   private final JwtTokenProvider jwtTokenProvider;
-  private final ChatRoomRepository chatRoomRepository;
   private final ChatService chatService;
 
   @MessageMapping("/chat/message")
   public void message(ChatMessage message, @Header("token") String token) {
-    String nickname = jwtTokenProvider.getMemberIdByAccessToken(token);
+    String senderId = jwtTokenProvider.getMemberIdByAccessToken(token);
 
-    message.setSender(nickname);
-    message.setUserCount(chatRoomRepository.getUserCount(message.getRoomId()));
-
+    // getMemberId의 return을 Long으로
+    message.setSenderId(Long.valueOf(senderId));
     chatService.sendChatMessage(message);
+  }
+
+  @RequestMapping("member/chat/message/enter")
+  public void enterMessage(ChatMessage message) {
+
+  }
+
+  @RequestMapping("member/chat/message/quit")
+  public void QuitMessage(ChatMessage message) {
+
   }
 }

--- a/green/src/main/java/com/greengrim/green/core/chat/ChatMessage.java
+++ b/green/src/main/java/com/greengrim/green/core/chat/ChatMessage.java
@@ -1,4 +1,4 @@
-package com.greengrim.green.core.chat.dto;
+package com.greengrim.green.core.chat;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -11,21 +11,19 @@ public class ChatMessage {
   }
 
   @Builder
-  public ChatMessage(MessageType type, String roomId, String sender, String message, long userCount) {
+  public ChatMessage(MessageType type, Long roomId, Long senderId, String message) {
     this.type = type;
     this.roomId = roomId;
-    this.sender = sender;
+    this.senderId = senderId;
     this.message = message;
-    this.userCount = userCount;
   }
 
   public enum MessageType {
       ENTER, QUIT, TALK;
   }
   private MessageType type;
-  private String roomId;
-  private String sender;
+  private Long roomId;
+  private Long senderId;
   private String message;
-  private long userCount;
 
 }

--- a/green/src/main/java/com/greengrim/green/core/chat/ChatService.java
+++ b/green/src/main/java/com/greengrim/green/core/chat/ChatService.java
@@ -1,8 +1,8 @@
 package com.greengrim.green.core.chat;
 
-import com.greengrim.green.core.chat.dto.ChatMessage;
-import com.greengrim.green.core.chat.dto.ChatMessage.MessageType;
+import com.greengrim.green.core.chat.ChatMessage.MessageType;
 import com.greengrim.green.core.chatRoom.ChatRoomRepository;
+import com.greengrim.green.core.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -14,7 +14,7 @@ public class ChatService {
 
   private final ChannelTopic channelTopic;
   private final RedisTemplate redisTemplate;
-  private final ChatRoomRepository chatRoomRepository;
+  private final MemberRepository memberRepository;
 
   public String getRoomId(String destination) {
     int lastIndex = destination.lastIndexOf('/');
@@ -25,16 +25,22 @@ public class ChatService {
   }
 
   public void sendChatMessage(ChatMessage chatMessage) {
-    chatMessage.setUserCount(chatRoomRepository.getUserCount(chatMessage.getRoomId()));
 
     if(MessageType.ENTER.equals(chatMessage.getType())) {
-      chatMessage.setMessage(chatMessage.getSender() + "님이 방에 입장했습니다.");
-      chatMessage.setSender("[알림]");
+
+      String senderNickName = memberRepository.findByIdAndStatusTrue(chatMessage.getSenderId())
+          .get().getNickName();
+
+      chatMessage.setMessage(senderNickName + "님이 방에 입장했습니다.");
     }
     else if (MessageType.QUIT.equals(chatMessage.getType())) {
-      chatMessage.setMessage(chatMessage.getSender() + "님이 방에서 나갔습니다.");
-      chatMessage.setSender("[알림]");
+
+      String senderNickName = memberRepository.findByIdAndStatusTrue(chatMessage.getSenderId())
+          .get().getNickName();
+
+      chatMessage.setMessage(senderNickName + "님이 방에서 나갔습니다.");
     }
+
     redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessage);
   }
 }

--- a/green/src/main/java/com/greengrim/green/core/chat/dto/ChatMessageEnterResponse.java
+++ b/green/src/main/java/com/greengrim/green/core/chat/dto/ChatMessageEnterResponse.java
@@ -1,0 +1,5 @@
+package com.greengrim.green.core.chat.dto;
+
+public class ChatMessageEnterResponse {
+
+}

--- a/green/src/main/java/com/greengrim/green/core/chatRoom/ChatRoom.java
+++ b/green/src/main/java/com/greengrim/green/core/chatRoom/ChatRoom.java
@@ -1,23 +1,29 @@
 package com.greengrim.green.core.chatRoom;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.io.Serializable;
-import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 
+
 @Getter
 @Setter
+@Entity
 public class ChatRoom implements Serializable {
 
   private static final long serialVersionUID = 6494678977089006639L;
-  private String roomId;
-  private String name;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long roomId;
+  private String title;
   private long userCount;
 
-  public static ChatRoom create(String name) {
+  public static ChatRoom create(String title) {
     ChatRoom chatRoom = new ChatRoom();
-    chatRoom.roomId = UUID.randomUUID().toString();
-    chatRoom.name = name;
+    chatRoom.title = title;
     return chatRoom;
   }
 

--- a/green/src/main/java/com/greengrim/green/core/chatRoom/ChatRoomController.java
+++ b/green/src/main/java/com/greengrim/green/core/chatRoom/ChatRoomController.java
@@ -1,6 +1,5 @@
 package com.greengrim.green.core.chatRoom;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,28 +11,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/chat")
+@RequestMapping("/member/chatRooms")
 public class ChatRoomController {
 
     private final ChatRoomRepository chatRoomRepository;
 
-    @GetMapping("/rooms")
+    @PostMapping
     @ResponseBody
-    public List<ChatRoom> room() {
-      List<ChatRoom> chatRooms = chatRoomRepository.findAllRoom();
-      chatRooms.stream().forEach(room->room.setUserCount(chatRoomRepository.getUserCount(room.getRoomId())));
-      return chatRoomRepository.findAllRoom();
+    public ChatRoom createRoom(@RequestParam String title) {
+      return chatRoomRepository.createChatRoom(title);
     }
 
-    @PostMapping("/room")
-    @ResponseBody
-    public ChatRoom createRoom(@RequestParam String name) {
-      return chatRoomRepository.createChatRoom(name);
-    }
-
-    @GetMapping("/room/enter/{roomId}")
-    public ChatRoom roomInfo(@PathVariable String roomId) {
+    @GetMapping("/{roomId}")
+    public ChatRoom roomInfo(@PathVariable Long roomId) {
       return chatRoomRepository.findRoomById(roomId);
     }
-
 }

--- a/green/src/main/java/com/greengrim/green/core/chatRoom/ChatRoomRepository.java
+++ b/green/src/main/java/com/greengrim/green/core/chatRoom/ChatRoomRepository.java
@@ -2,39 +2,33 @@ package com.greengrim.green.core.chatRoom;
 
 import jakarta.annotation.Resource;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
-
 public class ChatRoomRepository {
 
   private static final String CHAT_ROOMS = "CHAT_ROOM";
-  private static final String USER_COUNT = "USER_COUNT";
   private static final String ENTER_INFO = "ENTER_INFO";
 
   @Resource(name = "redisTemplate")
   private HashOperations<String, String, ChatRoom> hashOpsChatRoom;
   @Resource(name = "redisTemplate")
   private HashOperations<String, String, String> hashOpsEnterInfo;
-  @Resource(name = "redisTemplate")
-  private ValueOperations<String, String> valueOps;
 
   public List<ChatRoom> findAllRoom() {
    return hashOpsChatRoom.values(CHAT_ROOMS);
   }
 
-  public ChatRoom findRoomById(String id) {
+  public ChatRoom findRoomById(Long id) {
     return hashOpsChatRoom.get(CHAT_ROOMS, id);
   }
 
-  public ChatRoom createChatRoom(String name) {
-    ChatRoom chatRoom = ChatRoom.create(name);
-    hashOpsChatRoom.put(CHAT_ROOMS, chatRoom.getRoomId(), chatRoom);
+  public ChatRoom createChatRoom(String title) {
+    ChatRoom chatRoom = ChatRoom.create(title);
+    hashOpsChatRoom.put(CHAT_ROOMS, String.valueOf(chatRoom.getRoomId()), chatRoom);
     return chatRoom;
   }
 
@@ -50,16 +44,7 @@ public class ChatRoomRepository {
     hashOpsEnterInfo.delete(ENTER_INFO, sessionId);
   }
 
-  public long getUserCount(String roomId) {
-    return Long.valueOf(Optional.ofNullable(valueOps.get(USER_COUNT + "_" + roomId)).orElse("0"));
+  public void removeChatRoom(String roomId) {
+    hashOpsChatRoom.delete(CHAT_ROOMS, roomId);
   }
-
-  public long plusUserCount(String roomId) {
-    return Optional.ofNullable(valueOps.increment(USER_COUNT + "_"+ roomId)).orElse(0L);
-  }
-
-  public long minusUserCount(String roomId) {
-    return Optional.ofNullable(valueOps.decrement(USER_COUNT + "_"+ roomId)).filter( count->count > 0).orElse(0L);
-  }
-
 }


### PR DESCRIPTION
### ❗️ #28 


### 📝 구현 내용

채팅 refoctor 테스트입니다. 
- userCount를 챌린지 도메인에서 계산하도록 하여 메시지의 크기를 줄임
- stomp 통신 중 subscribe 요청 시 입장에서 Enter 타입 메시지 요청 시 입장으로 수정 



