### PR TITLE
NFT 관련 Entity 구현과 출석체크 에러 수정

### DIFF
--- a/green/src/main/java/com/greengrim/green/core/keyword/Keyword.java
+++ b/green/src/main/java/com/greengrim/green/core/keyword/Keyword.java
@@ -8,10 +8,12 @@ import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class Keyword extends BaseTime {
 
     @Id

--- a/green/src/main/java/com/greengrim/green/core/member/Member.java
+++ b/green/src/main/java/com/greengrim/green/core/member/Member.java
@@ -1,6 +1,7 @@
 package com.greengrim.green.core.member;
 
 import com.greengrim.green.common.entity.BaseTime;
+import com.greengrim.green.core.wallet.Wallet;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
@@ -49,6 +50,10 @@ public class Member extends BaseTime {
     @NotNull
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @OneToOne
+    @JoinColumn(name = "wallet_id")
+    private Wallet wallet;
 
     public void changeRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/green/src/main/java/com/greengrim/green/core/member/Member.java
+++ b/green/src/main/java/com/greengrim/green/core/member/Member.java
@@ -38,7 +38,7 @@ public class Member extends BaseTime {
     private boolean status;
 
     @NotNull
-    private Integer reportCnt;
+    private Integer reportCount;
 
     @NotNull
     private String refreshToken;

--- a/green/src/main/java/com/greengrim/green/core/member/Member.java
+++ b/green/src/main/java/com/greengrim/green/core/member/Member.java
@@ -52,8 +52,8 @@ public class Member extends BaseTime {
     private Role role;
 
     @OneToOne
-    @JoinColumn(name = "wallet_id")
     private Wallet wallet;
+
 
     public void changeRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/green/src/main/java/com/greengrim/green/core/nft/Nft.java
+++ b/green/src/main/java/com/greengrim/green/core/nft/Nft.java
@@ -1,0 +1,48 @@
+package com.greengrim.green.core.nft;
+
+import com.greengrim.green.common.entity.BaseTime;
+import com.greengrim.green.core.member.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Nft extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String nftId;
+    @NotNull
+    private String title;
+    @NotNull
+    private String description;
+    @NotNull
+    private String contracts;
+    @NotNull
+    private String txHash;
+    @NotNull
+    private String imgUrl;
+    @NotNull
+    private int reportCount;
+    @NotNull
+    private boolean status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+}

--- a/green/src/main/java/com/greengrim/green/core/transaction/Transaction.java
+++ b/green/src/main/java/com/greengrim/green/core/transaction/Transaction.java
@@ -2,6 +2,7 @@ package com.greengrim.green.core.transaction;
 
 import com.greengrim.green.common.entity.BaseTime;
 import com.greengrim.green.core.nft.Nft;
+import com.greengrim.green.core.transaction.dto.TransactionRequest.TransactionSetDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -46,4 +47,9 @@ public class Transaction extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private Nft nft;
 
+    public void setTransactionSet(TransactionSetDto transactionSet) {
+        this.payTransaction = transactionSet.getPayTransaction();
+        this.payBackTransaction = transactionSet.getPayBackTransaction();
+        this.feeTransaction = transactionSet.getFeeTransaction();
+    }
 }

--- a/green/src/main/java/com/greengrim/green/core/transaction/Transaction.java
+++ b/green/src/main/java/com/greengrim/green/core/transaction/Transaction.java
@@ -1,0 +1,49 @@
+package com.greengrim.green.core.transaction;
+
+import com.greengrim.green.common.entity.BaseTime;
+import com.greengrim.green.core.nft.Nft;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Transaction extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private TransactionType type;
+
+    @NotNull
+    private Long buyerId;
+    @NotNull
+    private Long sellerId;
+
+    @NotNull
+    private Double payAmount;
+    @NotNull
+    private Double payBackAmount;
+
+    @NotNull
+    private String payTransaction;
+    @NotNull
+    private String payBackTransaction;
+    @NotNull
+    private String feeTransaction;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Nft nft;
+
+}

--- a/green/src/main/java/com/greengrim/green/core/transaction/TransactionType.java
+++ b/green/src/main/java/com/greengrim/green/core/transaction/TransactionType.java
@@ -1,4 +1,12 @@
 package com.greengrim.green.core.transaction;
 
 public enum TransactionType {
+    MINTING("NFT 발행"),
+    SWAP1("클레이를 그린으로 스왑"),
+    SWAP2("그린을 클레이로 스왑"),
+    SEND_OUT_KLAY("클레이 외부 전송"),
+    DEAL("거래");
+
+    TransactionType(String name) {
+    }
 }

--- a/green/src/main/java/com/greengrim/green/core/transaction/TransactionType.java
+++ b/green/src/main/java/com/greengrim/green/core/transaction/TransactionType.java
@@ -1,0 +1,4 @@
+package com.greengrim.green.core.transaction;
+
+public enum TransactionType {
+}

--- a/green/src/main/java/com/greengrim/green/core/transaction/dto/TransactionRequest.java
+++ b/green/src/main/java/com/greengrim/green/core/transaction/dto/TransactionRequest.java
@@ -1,0 +1,18 @@
+package com.greengrim.green.core.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TransactionRequest {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TransactionSetDto {
+        private String payTransaction;
+        private String payBackTransaction;
+        private String feeTransaction;
+    }
+
+}

--- a/green/src/main/java/com/greengrim/green/core/verification/VerificationRepository.java
+++ b/green/src/main/java/com/greengrim/green/core/verification/VerificationRepository.java
@@ -14,8 +14,7 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
             @Param("certificationId") Long certificationId);
 
     // 올바르지 않다 대답 개수
-    Integer countByMemberIdAndCertificationIdAndResponse(
-            @Param("memberId") Long memberId,
+    Integer countByCertificationIdAndResponse(
             @Param("certificationId") Long certificationId,
             @Param("response") boolean response);
 

--- a/green/src/main/java/com/greengrim/green/core/verification/VerificationService.java
+++ b/green/src/main/java/com/greengrim/green/core/verification/VerificationService.java
@@ -36,16 +36,16 @@ public class VerificationService {
         verificationRepository.save(verification);
 
         // 상호 검증 처리하기
-        verifyCertification(member.getId(), certification);
+        verifyCertification(certification);
     }
 
     /**
      * 상호 검증이 과반수에 도달했을 때 처리하는 함수
      */
-    public void verifyCertification(Long memberId, Certification certification) {
+    public void verifyCertification(Certification certification) {
         // 이 인증에 거짓이라고 답한 사람이 5명 이상이라면, 해당 인증은 실패한 인증이다.
         // (상호 검증 중단, 인증 비활성화 처리, 포인트 뺏기, 탄소 감소량 뺏기)
-        if(checkCertificationFailOrSuccess(memberId, certification.getId(), false)) {
+        if(checkCertificationFailOrSuccess(certification.getId(), false)) {
             // 인증 entity 상호 검증 실패 처리
             certification.setValidationFail();
             Member lier = certification.getMember();
@@ -55,7 +55,7 @@ public class VerificationService {
             lier.setCarbonReduction(-certification.getChallenge().getCategory().getCarbonReduction());
             memberRepository.save(lier);
         } // 진실이라고 답한 사람이 5명 이상이라면, 해당 인증은 성공한 인증이다. (상호 검증 중단)
-        else if(checkCertificationFailOrSuccess(memberId, certification.getId(), true)) {
+        else if(checkCertificationFailOrSuccess(certification.getId(), true)) {
             certification.setValidationSuccess();
         }
         // 인증 entity 에서 남은 상호 검증 횟수 1 줄이기
@@ -73,8 +73,8 @@ public class VerificationService {
     /**
      * 상호 검증이 과반수에 도달했는지 확인하는 함수
      */
-    private boolean checkCertificationFailOrSuccess(Long memberId, Long certificationId, boolean response) {
-        return verificationRepository.countByMemberIdAndCertificationIdAndResponse(
-                memberId, certificationId, response) >= 5;
+    private boolean checkCertificationFailOrSuccess(Long certificationId, boolean response) {
+        return verificationRepository.countByCertificationIdAndResponse(
+                certificationId, response) >= 5;
     }
 }

--- a/green/src/main/java/com/greengrim/green/core/wallet/Wallet.java
+++ b/green/src/main/java/com/greengrim/green/core/wallet/Wallet.java
@@ -1,0 +1,40 @@
+package com.greengrim.green.core.wallet;
+
+import com.greengrim.green.common.entity.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Wallet extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String address;
+
+    @NotNull
+    private String password;
+
+    @NotNull
+    private int wrongCount;
+
+    public Wallet(String address, String password) {
+        this.address = address;
+        this.password = password;
+        this.wrongCount = 0;
+    }
+
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

#9

<br><br>

### 📝 구현 내용
- Entity 구현
  - Wallet
  - Nft
  - Transaction
- 출석체크 에러 수정
  1. certificationId를 받고 해당 인증에 대한 verification(출석체크) 개수를 셈 
  2. 만약 올바르다고 대답(true)한 출석체크가 5개 이상이거나, 올바르지 않다고 대답(false)한 출석체크가 5개 이상이면 그 인증에 대한 상호 검증 종료
  3. 동시에 validation 값이 1로 바뀌어야 하는데 바뀌지 않았음
  4. verification 개수를 셀 때 memberId 함께 조회하는 실수가 있었음 
  5. 고쳤음  

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- (리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

<br><br>

### 💡 참고 자료

- (없다면 지워도 됩니다!)
